### PR TITLE
dev-storage-2: Implementing encrypted collision data storage

### DIFF
--- a/__mocks__/expo-secure-store.ts
+++ b/__mocks__/expo-secure-store.ts
@@ -1,9 +1,19 @@
-const store: Record<string, string> = {};
+export const store: Record<string, string> = {};
 
+// Async methods
 export const getItemAsync = jest.fn(async (key: string) => store[key] ?? null);
 export const setItemAsync = jest.fn(async (key: string, value: string) => {
   store[key] = value;
 });
 export const deleteItemAsync = jest.fn(async (key: string) => {
+  delete store[key];
+});
+
+// Synchronous methods
+export const getItem = jest.fn((key: string) => store[key] ?? null);
+export const setItem = jest.fn((key: string, value: string) => {
+  store[key] = value;
+});
+export const deleteItem = jest.fn((key: string) => {
   delete store[key];
 });

--- a/__mocks__/react-native-mmkv.ts
+++ b/__mocks__/react-native-mmkv.ts
@@ -1,0 +1,24 @@
+export const storage: Record<string, Record<string, string>> = {};
+
+export const createMMKV = jest.fn(
+  (config?: { id: string; encryptionKey?: string }) => {
+    const id = config?.id || "default";
+
+    if (!storage[id]) {
+      storage[id] = {};
+    }
+
+    return {
+      getString: jest.fn((key: string) => storage[id][key] ?? undefined),
+      set: jest.fn((key: string, value: string) => {
+        storage[id][key] = value;
+      }),
+      remove: jest.fn((key: string) => {
+        delete storage[id][key];
+      }),
+      clearAll: jest.fn(() => {
+        storage[id] = {};
+      }),
+    };
+  },
+);

--- a/__tests__/testUtils/resetStores.ts
+++ b/__tests__/testUtils/resetStores.ts
@@ -5,6 +5,25 @@ import { useVehicleFormStore } from "@/store/vehicleFormStore";
 import { useWitnessFormStore } from "@/store/witnessFormStore";
 
 export const resetAllStores = () => {
+  // Clear mock MMKV storage
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const mmkvMock = require("react-native-mmkv");
+  if (mmkvMock.storage) {
+    Object.keys(mmkvMock.storage).forEach((id: string) => {
+      mmkvMock.storage[id] = {};
+    });
+  }
+
+  // Clear mock expo-secure-store storage
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const secureStoreMock = require("expo-secure-store");
+  if (secureStoreMock.store) {
+    Object.keys(secureStoreMock.store).forEach((key: string) => {
+      delete secureStoreMock.store[key];
+    });
+  }
+
+  // Reset Zustand stores
   useCollisionStore.setState({ collisions: [] });
   useThemeStore.setState({ theme: "light" });
 

--- a/app.json
+++ b/app.json
@@ -11,7 +11,8 @@
       "supportsTablet": true,
       "infoPlist": {
         "NSCameraUsageDescription": "This app uses the camera to take photos of collision events."
-      }
+      },
+      "bundleIdentifier": "com.crashlog"
     },
     "android": {
       "adaptiveIcon": {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -13,6 +13,14 @@ const mockUseLocalSearchParams = jest.fn(() => ({}));
 
 jest.mock("react-native-get-random-values");
 
+jest.mock("react-native-mmkv");
+
+jest.mock("react-native/Libraries/Utilities/Appearance", () => ({
+  getColorScheme: jest.fn(() => "light"),
+  addChangeListener: jest.fn(),
+  removeChangeListener: jest.fn(),
+}));
+
 jest.mock("expo-font", () => ({
   isLoaded: jest.fn(() => true),
   loadAsync: jest.fn(() => Promise.resolve()),

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,7 @@
+// Learn more https://docs.expo.io/guides/customizing-metro
+const { getDefaultConfig } = require('expo/metro-config');
+
+/** @type {import('expo/metro-config').MetroConfig} */
+const config = getDefaultConfig(__dirname);
+
+module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,8 @@
         "react-native-gesture-handler": "~2.28.0",
         "react-native-get-random-values": "~1.11.0",
         "react-native-mask-text": "^0.15.0",
+        "react-native-mmkv": "^4.3.1",
+        "react-native-nitro-modules": "^0.35.7",
         "react-native-paper": "^5.14.5",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
@@ -12964,6 +12966,28 @@
       "dependencies": {
         "bignumber.js": "^9.0.1"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-mmkv": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-mmkv/-/react-native-mmkv-4.3.1.tgz",
+      "integrity": "sha512-APyGGaaHtayVgT18dBM8QGGZKr9pGfSTiBwbbPNzhGGfJQSU7awLGRGq879OqYl31HmVks9hOBLCs+qfgacRZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-nitro-modules": "*"
+      }
+    },
+    "node_modules/react-native-nitro-modules": {
+      "version": "0.35.7",
+      "resolved": "https://registry.npmjs.org/react-native-nitro-modules/-/react-native-nitro-modules-0.35.7.tgz",
+      "integrity": "sha512-3EiU27EmnxTlD3pAXR2OBWeDg7+9tdjKrNQOPX08rFX5hJPNIT/h1i2PjvTUieOypCGTEi9nW/SNBtK3F+4HYg==",
+      "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "lint": "expo lint",
     "test": "jest"
@@ -57,6 +57,8 @@
     "react-native-gesture-handler": "~2.28.0",
     "react-native-get-random-values": "~1.11.0",
     "react-native-mask-text": "^0.15.0",
+    "react-native-mmkv": "^4.3.1",
+    "react-native-nitro-modules": "^0.35.7",
     "react-native-paper": "^5.14.5",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",

--- a/store/collisionStore.ts
+++ b/store/collisionStore.ts
@@ -1,5 +1,7 @@
 import { Collision } from "@/lib/types";
-import { deleteItemAsync, getItemAsync, setItemAsync } from "expo-secure-store";
+import { getItem, setItem } from "expo-secure-store";
+import { createMMKV } from "react-native-mmkv";
+import { v4 as uuidv4 } from "uuid";
 import { create, StateCreator } from "zustand";
 import {
   createJSONStorage,
@@ -16,15 +18,27 @@ interface CollisionStore {
   updateCollision: (collision: Collision) => void;
 }
 
+let key = getItem("collision-key");
+if (!key) {
+  key = uuidv4();
+  setItem("collision-key", key);
+}
+
+const storage = createMMKV({
+  id: "crashlog-storage",
+  encryptionType: "AES-256",
+  encryptionKey: key,
+});
+
 const secureStorage: StateStorage = {
-  getItem: getItemAsync,
-  setItem: setItemAsync,
-  removeItem: deleteItemAsync,
+  getItem: (key) => storage.getString(key) ?? null,
+  setItem: (key, value) => storage.set(key, value),
+  removeItem: (key) => storage.remove(key),
 };
 
 type CollisionPersist = (
   config: StateCreator<CollisionStore>,
-  options: PersistOptions<CollisionStore>
+  options: PersistOptions<CollisionStore>,
 ) => StateCreator<CollisionStore>;
 
 export const useCollisionStore = create<CollisionStore, []>(
@@ -42,13 +56,13 @@ export const useCollisionStore = create<CollisionStore, []>(
       updateCollision: (collision: Collision) =>
         set({
           collisions: get().collisions.map((c) =>
-            c.id === collision.id ? collision : c
+            c.id === collision.id ? collision : c,
           ),
         }),
     }),
     {
       name: "collision-storage",
       storage: createJSONStorage(() => secureStorage),
-    }
-  )
+    },
+  ),
 );

--- a/store/themeStore.ts
+++ b/store/themeStore.ts
@@ -1,5 +1,5 @@
-import * as SecureStore from "expo-secure-store";
 import { Appearance } from "react-native";
+import { createMMKV } from "react-native-mmkv";
 import { create } from "zustand";
 import { createJSONStorage, persist, StateStorage } from "zustand/middleware";
 
@@ -11,10 +11,14 @@ interface ThemeStore {
   toggleTheme: () => void;
 }
 
+const storage = createMMKV({
+  id: "crashlog-storage",
+});
+
 const secureStorage: StateStorage = {
-  getItem: async (key) => await SecureStore.getItemAsync(key),
-  setItem: async (key, value) => await SecureStore.setItemAsync(key, value),
-  removeItem: async (key) => await SecureStore.deleteItemAsync(key),
+  getItem: (key) => storage.getString(key) ?? null,
+  setItem: (key, value) => storage.set(key, value),
+  removeItem: (key) => storage.remove(key),
 };
 
 export const useThemeStore = create<ThemeStore>()(

--- a/store/themeStore.ts
+++ b/store/themeStore.ts
@@ -15,7 +15,7 @@ const storage = createMMKV({
   id: "crashlog-storage",
 });
 
-const secureStorage: StateStorage = {
+const themeStorage: StateStorage = {
   getItem: (key) => storage.getString(key) ?? null,
   setItem: (key, value) => storage.set(key, value),
   removeItem: (key) => storage.remove(key),
@@ -33,7 +33,7 @@ export const useThemeStore = create<ThemeStore>()(
     }),
     {
       name: "theme-preference",
-      storage: createJSONStorage(() => secureStorage),
+      storage: createJSONStorage(() => themeStorage),
     },
   ),
 );


### PR DESCRIPTION
expo-secure-storage uses native keychain storage for auth / session management. Not meant for app state storage. 

I've replaced instances of expo-secure-storage for theme and app state, with react-native-mmkv, which supports key-based encryption. 

The encryption key is stored in expo-secure-storage (as it should)