### PR TITLE
dev-user-vehicle: Pre-fill vehicle + driver info

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,26 +1,44 @@
 import { CollisionList } from "@/components/collisions/CollisionList";
 import CustomFAB from "@/components/misc/CustomFAB";
 import ScreenContainer from "@/components/misc/ScreenContainer";
+import UserVehicleView from "@/components/vehicles/UserVehicleView";
 import { useCollisionFormStore } from "@/store/collisionFormStore";
 import { useRouter } from "expo-router";
+import { View } from "react-native";
+import { Divider, Text } from "react-native-paper";
 
 export default function Index() {
   const { resetForm } = useCollisionFormStore();
   const router = useRouter();
 
-  const handlePress = () => {
+  const addCollision = () => {
     resetForm();
     router.navigate("/collisions/form/safetyScreen");
   };
-
   return (
-    <ScreenContainer
-      gestureEnabled={false}
-      title="My Collisions"
-      backButton={false}
-    >
-      <CollisionList />
-      <CustomFAB icon="plus" label="Add Collision" handlePress={handlePress} />
+    <ScreenContainer gestureEnabled={false} title="CrashLog" backButton={false}>
+      <View style={{ marginBottom: 24 }}>
+        <Text
+          variant="titleMedium"
+          style={{ marginBottom: 12, fontWeight: "600" }}
+        >
+          My Vehicle
+        </Text>
+        <UserVehicleView />
+      </View>
+
+      <Divider bold style={{ marginBottom: 24 }} />
+
+      <View style={{ flex: 1 }}>
+        <Text
+          variant="titleMedium"
+          style={{ marginBottom: 12, fontWeight: "600" }}
+        >
+          My Collisions
+        </Text>
+        <CollisionList />
+      </View>
+      <CustomFAB icon="plus" label="Add Collision" handlePress={addCollision} />
     </ScreenContainer>
   );
 }

--- a/app/prefillVehicleScreen.tsx
+++ b/app/prefillVehicleScreen.tsx
@@ -46,7 +46,7 @@ const prefillVehicleScreen = () => {
   };
   return (
     <ScreenContainer
-      title={"Add Vehicle"}
+      title={"My Vehicle"}
       description={
         "Provide the following information about your vehicle and you as a driver"
       }

--- a/app/prefillVehicleScreen.tsx
+++ b/app/prefillVehicleScreen.tsx
@@ -2,12 +2,11 @@ import DriverCard from "@/components/driver/DriverCard";
 import DriverDialog from "@/components/driver/DriverDialog";
 import ErrorBox from "@/components/misc/ErrorBox";
 import ScreenContainer from "@/components/misc/ScreenContainer";
-import VehicleDraftButton from "@/components/vehicles/VehicleDraftButton";
 import { styles } from "@/lib/themes";
 import { Vehicle } from "@/lib/types";
 import { validateVehicle } from "@/lib/validators";
-import { useCollisionFormStore } from "@/store/collisionFormStore";
 import { useVehicleFormStore } from "@/store/vehicleFormStore";
+import { useVehicleStore } from "@/store/vehicleStore";
 import { router } from "expo-router";
 import React, { useState } from "react";
 import { KeyboardAvoidingView, Platform, ScrollView, View } from "react-native";
@@ -22,9 +21,9 @@ type VehicleFormErrors = {
   policyNumber?: string[];
 };
 
-const VehicleFormScreen = () => {
-  const { vehicle, updateVehicleField, isEdit } = useVehicleFormStore();
-  const { upsertVehicle } = useCollisionFormStore();
+const prefillVehicleScreen = () => {
+  const { vehicle, updateVehicleField } = useVehicleFormStore();
+  const { setVehicle } = useVehicleStore();
   const {
     make,
     model,
@@ -41,18 +40,15 @@ const VehicleFormScreen = () => {
     if (Object.keys(parseErrors).length !== 0) {
       setFormErrors(parseErrors);
     } else {
-      if ("savePoint" in vehicle) {
-        delete vehicle.savePoint;
-      }
-      upsertVehicle(vehicle as Vehicle);
+      setVehicle(vehicle as Vehicle);
       router.back();
     }
   };
   return (
     <ScreenContainer
-      title={isEdit ? "Edit Vehicle" : "Add Vehicle"}
+      title={"Add Vehicle"}
       description={
-        "Provide as much detail as possible about the vehicle involved."
+        "Provide the following information about your vehicle and you as a driver"
       }
       backButton
     >
@@ -183,11 +179,6 @@ const VehicleFormScreen = () => {
             marginVertical: 10,
           }}
         >
-          <VehicleDraftButton
-            mode="outlined"
-            style={{ flex: 1 }}
-            children="Save Draft"
-          />
           <Button mode="contained" style={{ flex: 2 }} onPress={handleSubmit}>
             Save Vehicle
           </Button>
@@ -197,4 +188,4 @@ const VehicleFormScreen = () => {
   );
 };
 
-export default VehicleFormScreen;
+export default prefillVehicleScreen;

--- a/app/userVehicleScreen.tsx
+++ b/app/userVehicleScreen.tsx
@@ -21,7 +21,7 @@ type VehicleFormErrors = {
   policyNumber?: string[];
 };
 
-const prefillVehicleScreen = () => {
+const userVehicleScreen = () => {
   const { vehicle, updateVehicleField } = useVehicleFormStore();
   const { setVehicle } = useVehicleStore();
   const {
@@ -188,4 +188,4 @@ const prefillVehicleScreen = () => {
   );
 };
 
-export default prefillVehicleScreen;
+export default userVehicleScreen;

--- a/components/misc/CustomAlertDialog.tsx
+++ b/components/misc/CustomAlertDialog.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Modal, View } from "react-native";
-import { Button } from "react-native-paper";
+import { View } from "react-native";
+import { Button, Text } from "react-native-paper";
+import CustomModal from "./CustomModal";
 
 type CustomAlertDialogProps = {
   message: string;
@@ -16,13 +17,31 @@ const CustomAlertDialog = ({
   onClose,
 }: CustomAlertDialogProps) => {
   return (
-    <Modal visible={isDialogVisible} onRequestClose={onClose}>
-      <View>{message}</View>
-      <View>
-        <Button onPress={onClose}>No</Button>
-        <Button onPress={onSuccess}>Yes</Button>
+    <CustomModal isVisible={isDialogVisible} onClose={onClose}>
+      <Text
+        variant="bodyLarge"
+        style={{
+          marginLeft: 10,
+          paddingTop: 5,
+        }}
+      >
+        {message}
+      </Text>
+      <View
+        style={{
+          flexDirection: "row",
+          justifyContent: "flex-end",
+          marginVertical: 10,
+        }}
+      >
+        <Button onPress={onClose} mode="contained" style={{ marginRight: 5 }}>
+          No
+        </Button>
+        <Button onPress={onSuccess} mode="contained">
+          Yes
+        </Button>
       </View>
-    </Modal>
+    </CustomModal>
   );
 };
 

--- a/components/vehicles/UserVehicleView.tsx
+++ b/components/vehicles/UserVehicleView.tsx
@@ -27,7 +27,7 @@ const UserVehicleView = () => {
           vehicle={vehicle}
           index={0}
           showActions
-          editRoute="/prefillVehicleScreen"
+          editRoute="/userVehicleScreen"
           onDelete={handleDelete}
         />
       ) : (
@@ -48,7 +48,7 @@ const UserVehicleView = () => {
             </Text>
             <Button
               mode="contained"
-              onPress={() => router.navigate("/prefillVehicleScreen")}
+              onPress={() => router.navigate("/userVehicleScreen")}
             >
               Add My Vehicle
             </Button>

--- a/components/vehicles/UserVehicleView.tsx
+++ b/components/vehicles/UserVehicleView.tsx
@@ -1,0 +1,68 @@
+import { useVehicleStore } from "@/store/vehicleStore";
+import { useRouter } from "expo-router";
+import React, { useState } from "react";
+import { View } from "react-native";
+import { Button, Card, Text } from "react-native-paper";
+import CustomAlertDialog from "../misc/CustomAlertDialog";
+import VehicleCard from "./VehicleCard";
+
+const UserVehicleView = () => {
+  const { vehicle, deleteVehicle } = useVehicleStore();
+  const router = useRouter();
+  const [isDeleteDialogVisible, setIsDeleteDialogVisible] = useState(false);
+
+  const handleDelete = () => {
+    setIsDeleteDialogVisible(true);
+  };
+
+  const handleConfirmDelete = () => {
+    deleteVehicle();
+    setIsDeleteDialogVisible(false);
+  };
+
+  return (
+    <View>
+      {vehicle ? (
+        <VehicleCard
+          vehicle={vehicle}
+          index={0}
+          showActions
+          editRoute="/prefillVehicleScreen"
+          onDelete={handleDelete}
+        />
+      ) : (
+        <Card mode="contained" style={{ marginBottom: 10 }}>
+          <Card.Content style={{ alignItems: "center", padding: 20 }}>
+            <Text variant="titleMedium" style={{ marginBottom: 8 }}>
+              No vehicle saved
+            </Text>
+            <Text
+              variant="bodyMedium"
+              style={{
+                marginBottom: 16,
+                textAlign: "center",
+                opacity: 0.7,
+              }}
+            >
+              Save your vehicle information to quickly fill collision reports
+            </Text>
+            <Button
+              mode="contained"
+              onPress={() => router.navigate("/prefillVehicleScreen")}
+            >
+              Add My Vehicle
+            </Button>
+          </Card.Content>
+        </Card>
+      )}
+      <CustomAlertDialog
+        message="Are you sure you want to delete your saved vehicle information? This action cannot be undone."
+        onSuccess={handleConfirmDelete}
+        onClose={() => setIsDeleteDialogVisible(false)}
+        isDialogVisible={isDeleteDialogVisible}
+      />
+    </View>
+  );
+};
+
+export default UserVehicleView;

--- a/components/vehicles/VehicleCard.tsx
+++ b/components/vehicles/VehicleCard.tsx
@@ -11,6 +11,8 @@ type VehicleCardProps = {
   vehicle: Vehicle | DraftVehicle;
   index: number;
   showActions?: boolean;
+  editRoute?: string;
+  onDelete?: () => void;
 };
 
 const isDraftVehicle = (
@@ -23,6 +25,8 @@ const VehicleCard = ({
   vehicle,
   index,
   showActions = false,
+  editRoute,
+  onDelete,
 }: VehicleCardProps) => {
   const {
     make,
@@ -91,15 +95,27 @@ const VehicleCard = ({
             </Text>
           </View>
           {showActions && (
-            <IconButton
-              icon={"pencil"}
-              onPress={() => {
-                setForm(vehicle);
-                router.navigate("/collisions/form/vehicleFormScreen");
-                setEdit(true);
-              }}
-              style={{ margin: 0 }}
-            />
+            <View style={{ flexDirection: "row", gap: 4 }}>
+              <IconButton
+                icon={"pencil"}
+                onPress={() => {
+                  setForm(vehicle);
+                  router.navigate(
+                    (editRoute || "/collisions/form/vehicleFormScreen") as any,
+                  );
+                  setEdit(true);
+                }}
+                style={{ margin: 0 }}
+              />
+              {onDelete && (
+                <IconButton
+                  icon={"delete"}
+                  iconColor={theme.colors.error}
+                  onPress={onDelete}
+                  style={{ margin: 0 }}
+                />
+              )}
+            </View>
           )}
         </View>
         <Divider bold style={{ marginTop: 10, marginBottom: 10 }} />

--- a/components/vehicles/VehicleList.tsx
+++ b/components/vehicles/VehicleList.tsx
@@ -7,6 +7,7 @@ import VehicleCard from "./VehicleCard";
 
 const VehicleList = () => {
   const { collision, deleteVehicle } = useCollisionFormStore();
+
   const { vehicles } = collision;
   const theme = useTheme();
 

--- a/store/collisionFormStore.ts
+++ b/store/collisionFormStore.ts
@@ -2,6 +2,7 @@ import { Collision, Vehicle, Witness } from "@/lib/types";
 import "react-native-get-random-values";
 import { v4 as uuidv4 } from "uuid";
 import { create } from "zustand";
+import { useVehicleStore } from "./vehicleStore";
 
 interface CollisionFormStore {
   collision: Collision;
@@ -28,12 +29,13 @@ const newLocation = () => ({
 });
 
 const newCollision = () => {
+  const { vehicle } = useVehicleStore.getState();
   return {
     id: "" + uuidv4(),
     date: new Date(),
     location: newLocation(),
     description: "",
-    vehicles: [],
+    vehicles: vehicle ? [vehicle] : [],
     witnesses: [],
     media: [],
     officer: null,

--- a/store/vehicleStore.ts
+++ b/store/vehicleStore.ts
@@ -1,0 +1,24 @@
+import { mmkvStorage } from "@/lib/storage";
+import { Vehicle } from "@/lib/types";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+interface VehicleStore {
+  vehicle: Vehicle | null;
+  setVehicle: (v: Vehicle) => void;
+  getVehicle: () => Vehicle | null;
+}
+
+export const useVehicleStore = create<VehicleStore>()(
+  persist(
+    (set, get): VehicleStore => ({
+      vehicle: null,
+      setVehicle: (v: Vehicle) => set({ vehicle: v }),
+      getVehicle: () => get().vehicle,
+    }),
+    {
+      name: "vehicle-storage",
+      storage: createJSONStorage(() => mmkvStorage),
+    },
+  ),
+);

--- a/store/vehicleStore.ts
+++ b/store/vehicleStore.ts
@@ -7,14 +7,20 @@ interface VehicleStore {
   vehicle: Vehicle | null;
   setVehicle: (v: Vehicle) => void;
   getVehicle: () => Vehicle | null;
+  askedForVehicle: boolean;
+  setAskedForVehicle: (value: boolean) => void;
+  getAskedForVehicle: () => boolean;
 }
 
 export const useVehicleStore = create<VehicleStore>()(
   persist(
     (set, get): VehicleStore => ({
       vehicle: null,
+      askedForVehicle: false,
       setVehicle: (v: Vehicle) => set({ vehicle: v }),
       getVehicle: () => get().vehicle,
+      setAskedForVehicle: (value: boolean) => set({ askedForVehicle: value }),
+      getAskedForVehicle: () => get().askedForVehicle,
     }),
     {
       name: "vehicle-storage",

--- a/store/vehicleStore.ts
+++ b/store/vehicleStore.ts
@@ -2,25 +2,24 @@ import { mmkvStorage } from "@/lib/storage";
 import { Vehicle } from "@/lib/types";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
+import { useVehicleFormStore } from "./vehicleFormStore";
 
 interface VehicleStore {
   vehicle: Vehicle | null;
-  setVehicle: (v: Vehicle) => void;
-  getVehicle: () => Vehicle | null;
-  askedForVehicle: boolean;
-  setAskedForVehicle: (value: boolean) => void;
-  getAskedForVehicle: () => boolean;
+  setVehicle: (v: Vehicle | null) => void;
+  deleteVehicle: () => void;
 }
 
 export const useVehicleStore = create<VehicleStore>()(
   persist(
     (set, get): VehicleStore => ({
       vehicle: null,
-      askedForVehicle: false,
-      setVehicle: (v: Vehicle) => set({ vehicle: v }),
-      getVehicle: () => get().vehicle,
-      setAskedForVehicle: (value: boolean) => set({ askedForVehicle: value }),
-      getAskedForVehicle: () => get().askedForVehicle,
+      setVehicle: (v: Vehicle | null) => set({ vehicle: v }),
+      deleteVehicle: () => {
+        const { resetForm } = useVehicleFormStore.getState();
+        set({ vehicle: null });
+        resetForm();
+      },
     }),
     {
       name: "vehicle-storage",


### PR DESCRIPTION
Solves Issue #24 

Users wanted to store their vehicle and driver info beforehand to save time filling out info after a collision. 

Added new route and state store for a user's vehicle, and logic to pre-fill a collision's vehicle collection with the user's vehicle.